### PR TITLE
test: fix gcc-14.x compile (implicit int)

### DIFF
--- a/test.c
+++ b/test.c
@@ -11,7 +11,7 @@ static void print_hex(const char* data, size_t size)
         printf("%x%x", ((unsigned char)data[i])/16, ((unsigned char)data[i])%16);
 }
 
-static num_test;
+static int num_test;
 
 static int do_test(const char* data, size_t size, const char* expected_dgst)
 {


### PR DESCRIPTION
Fixes:

  test.c:14:8: error: type defaults to ‘int’ in declaration of ‘num_test’ [-Wimplicit-int]
     14 | static num_test;
        |        ^~~~~~~~